### PR TITLE
Changes for newest Nim (devel) and OSX.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
     "cwd": "${workspaceRoot}"
   },
   "osx": {
-    "command": "nim"
+    "command": "${workspaceRoot}/build.sh"
   },
   "isShellCommand": true,
   "tasks": [

--- a/Source/PlatformerGame/UI/Menu/PlatformerOptions.nim
+++ b/Source/PlatformerGame/UI/Menu/PlatformerOptions.nim
@@ -74,7 +74,7 @@ class FPlatformerOptions of FGameMenuPage:
     userSettings = ueCast[UPlatformerGameUserSettings](gEngine.getGameUserSettings())
     videoResolutionOption.get().selectedMultiChoice = getCurrentResolutionIndex(userSettings.get().getScreenResolution())
     fullScreenOption.get().selectedMultiChoice = if userSettings.get().getFullscreenMode() != EWindowMode.Windowed: 1 else: 0
-    soundVolumeOption.get().selectedMultiChoice = round(trunc(userSettings.getSoundVolume() * 10.0'f32))
+    soundVolumeOption.get().selectedMultiChoice = toInt(trunc(userSettings.getSoundVolume() * 10.0'f32))
 
   proc applySettings*() =
     ## applies changes in game settings

--- a/Source/PlatformerGame/UI/PlatformerHUD.nim
+++ b/Source/PlatformerGame/UI/PlatformerHUD.nim
@@ -33,11 +33,11 @@ proc describeTime*(timeSeconds: float32, bShowSign: bool = true): FString =
   let absTimeSeconds = abs(timeSeconds)
   let isNegative = timeSeconds < 0
 
-  let totalSeconds: int32 = round(trunc(absTimeSeconds)) mod 3600
+  let totalSeconds: int32 = toInt(trunc(absTimeSeconds)) mod 3600
   let numMinutes: int32 = totalSeconds div 60
   let numSeconds: int32 = totalSeconds mod 60
 
-  let numMilliseconds = round(trunc((absTimeSeconds - trunc(absTimeSeconds)) * 1000.0))
+  let numMilliseconds = toInt(trunc((absTimeSeconds - trunc(absTimeSeconds)) * 1000.0))
 
   result = printfToFString(u16"%s%02d:%02d.%03d",
                             if bShowSign: (if isNegative: u16"-" else: u16"+") else: u16"",


### PR DESCRIPTION
- round() now returns a float. Changed to toInt() which rounds to int.
  As you use trunc it does not matter how it rounds (0.5+ rounds up).
- Small fix for OSX Build in vsc.
